### PR TITLE
카카오 로그인 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,6 +96,7 @@ lib/generated_plugin_registrant.dart
 ### Xcode ###
 ## User settings
 xcuserdata/
+*.xcconfig
 
 ## Xcode 8 and earlier
 *.xcscmblueprint

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.configuration.updateBuildConfiguration": "interactive"
+}

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,3 +1,11 @@
+def localProperties = new Properties()
+def localPropertiesFile = rootProject.file('local.properties')
+if (localPropertiesFile.exists()) {
+    localPropertiesFile.withReader('UTF-8') { reader ->
+        localProperties.load(reader)
+    }
+}
+
 plugins {
     id "com.android.application"
     id "kotlin-android"
@@ -28,6 +36,9 @@ android {
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName
+        manifestPlaceholders = [
+            kakaoNativeAppKey: localProperties.getProperty('kakao.native.app.key', '')
+        ]
     }
 
     buildTypes {

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -25,6 +25,22 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+
+        <!-- 카카오 로그인 커스텀 URL 스킴 설정 -->
+        <activity 
+            android:name="com.kakao.sdk.flutter.AuthCodeCustomTabsActivity"
+            android:exported="true">
+            <intent-filter android:label="flutter_web_auth">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <!-- "kakao${kakaoNativeAppKey}://oauth" 형식의 앱 실행 스킴 설정 -->
+                <!-- 카카오 로그인 Redirect URI -->
+                <data android:scheme="kakao${kakaoNativeAppKey}" android:host="oauth"/>
+            </intent-filter>
+        </activity>
+
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
         <meta-data

--- a/ios/Flutter/Debug.xcconfig
+++ b/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/ios/Flutter/Release.xcconfig
+++ b/ios/Flutter/Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,0 +1,44 @@
+# Uncomment this line to define a global platform for your project
+# platform :ios, '12.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+  use_modular_headers!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		9C9E24ED2D11A9BC003B01EF /* Config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -90,6 +91,7 @@
 		97C146E51CF9000F007C117D = {
 			isa = PBXGroup;
 			children = (
+				9C9E24ED2D11A9BC003B01EF /* Config.xcconfig */,
 				9740EEB11CF90186004384FC /* Flutter */,
 				97C146F01CF9000F007C117D /* Runner */,
 				97C146EF1CF9000F007C117D /* Products */,
@@ -425,6 +427,7 @@
 		};
 		97C147031CF9000F007C117D /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 9C9E24ED2D11A9BC003B01EF /* Config.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -482,6 +485,7 @@
 		};
 		97C147041CF9000F007C117D /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 9C9E24ED2D11A9BC003B01EF /* Config.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
@@ -20,9 +22,29 @@
 	<string>$(FLUTTER_BUILD_NAME)</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>kakao${KAKAO_NATIVE_APP_KEY}</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
+	<key>KAKAO_NATIVE_APP_KEY</key>
+	<string>${KAKAO_NATIVE_APP_KEY}</string>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>kakaokompassauth</string>
+		<string>kakaolink</string>
+	</array>
 	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
@@ -41,9 +63,5 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>CADisableMinimumFrameDurationOnPhone</key>
-	<true/>
-	<key>UIApplicationSupportsIndirectInputEvents</key>
-	<true/>
 </dict>
 </plist>

--- a/lib/core/errors/auth_failure.dart
+++ b/lib/core/errors/auth_failure.dart
@@ -1,0 +1,15 @@
+import 'package:trip_view/core/errors/failure.dart';
+
+class AuthFailure extends Failure {
+  AuthFailure(super.message);
+}
+
+// 카카오 로그인 실패
+class KakaoSignInFailure extends AuthFailure {
+  KakaoSignInFailure(super.message);
+}
+
+// 로그아웃 실패
+class SignOutFailure extends AuthFailure {
+  SignOutFailure(super.message);
+}

--- a/lib/core/errors/failure.dart
+++ b/lib/core/errors/failure.dart
@@ -1,0 +1,4 @@
+abstract class Failure {
+  final String message;
+  Failure(this.message);
+}

--- a/lib/core/network/response_model.dart
+++ b/lib/core/network/response_model.dart
@@ -1,0 +1,31 @@
+// 성공 응답용 모델
+class ApiResponse<T> {
+  final int statusCode;
+  final String message;
+  final DateTime timestamp;
+  final String requestURL;
+  final T? data;
+
+  ApiResponse({
+    required this.statusCode,
+    required this.message,
+    required this.timestamp,
+    required this.requestURL,
+    required this.data,
+  });
+}
+
+// 실패 응답용 모델
+class ApiError {
+  final int statusCode;
+  final String message;
+  final DateTime timestamp;
+  final String requestURL;
+
+  ApiError({
+    required this.statusCode,
+    required this.message,
+    required this.timestamp,
+    required this.requestURL,
+  });
+}

--- a/lib/features/auth/data/datasources/auth_data_source.dart
+++ b/lib/features/auth/data/datasources/auth_data_source.dart
@@ -1,0 +1,50 @@
+import 'package:trip_view/core/network/response_model.dart';
+import 'package:trip_view/features/auth/domain/entities/user.dart';
+
+abstract class AuthDataSource {
+  Future<ApiResponse<User>> getTokenWithKakaoAuthCode(String authCode);
+  Future<void> signOut();
+}
+
+class AuthMockDataSourceImpl implements AuthDataSource {
+  @override
+  Future<ApiResponse<User>> getTokenWithKakaoAuthCode(String authCode) async {
+    // 실제 API 호출처럼 보이게 딜레이 추가
+    await Future.delayed(const Duration(seconds: 2));
+
+    return ApiResponse(
+      statusCode: 200,
+      message: "로그인 성공",
+      timestamp: DateTime.now(),
+      requestURL: "/auth/kakao",
+      data: User(
+          id: "mock_user_id",
+          name: "홍길동",
+          email: "test@example.com",
+          nickname: "길동이",
+          profileImageUrl: "https://example.com/profile.jpg",
+          accessToken: "mock_access_token_${authCode}",
+          refreshToken: "mock_refresh_token"),
+    );
+  }
+
+  @override
+  Future<void> signOut() {
+    // 추후 구현
+    throw UnimplementedError();
+  }
+}
+
+class AuthDataSourceImpl implements AuthDataSource {
+  @override
+  Future<ApiResponse<User>> getTokenWithKakaoAuthCode(String authCode) {
+    // 추후 구현
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> signOut() {
+    // 추후 구현
+    throw UnimplementedError();
+  }
+}

--- a/lib/features/auth/data/repositories/auth_repository_impl.dart
+++ b/lib/features/auth/data/repositories/auth_repository_impl.dart
@@ -1,0 +1,54 @@
+import 'package:dartz/dartz.dart';
+import 'package:kakao_flutter_sdk_auth/kakao_flutter_sdk_auth.dart';
+import 'package:trip_view/core/errors/failure.dart';
+import 'package:trip_view/core/network/response_model.dart';
+import 'package:trip_view/features/auth/data/datasources/auth_data_source.dart';
+import 'package:trip_view/features/auth/domain/entities/user.dart';
+
+import '../../../../core/errors/auth_failure.dart';
+import '../../domain/repositories/auth_reopository.dart';
+
+class AuthRepositoryImpl implements AuthRepository {
+  final AuthDataSource dataSource;
+
+  AuthRepositoryImpl(this.dataSource);
+
+  @override
+  Future<Either<Failure, ApiResponse<User>>> signInWithKakao() async {
+    try {
+      // 1. 인가 코드 발급
+      String authCode;
+      try {
+        if (await isKakaoTalkInstalled()) {
+          authCode =
+              await AuthCodeClient.instance.authorizeWithTalk(redirectUri: '');
+        } else {
+          authCode = await AuthCodeClient.instance.authorize(redirectUri: '');
+        }
+      } on Exception catch (e) {
+        return Left(KakaoSignInFailure("카카오 인가 코드 발급 실패: ${e.toString()}"));
+      }
+
+      // 2. 인가 코드를 사용하여 토큰 발급
+      if (authCode.isNotEmpty) {
+        final response = await dataSource.getTokenWithKakaoAuthCode(authCode);
+        return Right(response);
+      } else {
+        return Left(KakaoSignInFailure("인가 코드 발급 실패"));
+      }
+    } catch (e) {
+      return Left(KakaoSignInFailure(e.toString()));
+    }
+  }
+
+  // 추후 수정 필요
+  @override
+  Future<Either<Failure, void>> signOut() async {
+    try {
+      await dataSource.signOut();
+      return const Right(null);
+    } catch (e) {
+      return Left(KakaoSignInFailure(e.toString()));
+    }
+  }
+}

--- a/lib/features/auth/domain/entities/user.dart
+++ b/lib/features/auth/domain/entities/user.dart
@@ -1,0 +1,15 @@
+class User {
+  final String id;
+  final String name;
+  final String email;
+  final String? nickname;
+  final String? profileImageUrl;
+
+  User({
+    required this.id,
+    required this.name,
+    required this.email,
+    this.nickname,
+    this.profileImageUrl,
+  });
+}

--- a/lib/features/auth/domain/entities/user.dart
+++ b/lib/features/auth/domain/entities/user.dart
@@ -2,6 +2,8 @@ class User {
   final String id;
   final String name;
   final String email;
+  final String accessToken;
+  final String refreshToken;
   final String? nickname;
   final String? profileImageUrl;
 
@@ -9,6 +11,8 @@ class User {
     required this.id,
     required this.name,
     required this.email,
+    required this.accessToken,
+    required this.refreshToken,
     this.nickname,
     this.profileImageUrl,
   });

--- a/lib/features/auth/domain/repositories/auth_reopository.dart
+++ b/lib/features/auth/domain/repositories/auth_reopository.dart
@@ -1,11 +1,12 @@
 import 'package:dartz/dartz.dart';
+import 'package:trip_view/core/network/response_model.dart';
+import 'package:trip_view/features/auth/domain/entities/user.dart';
 
 import '../../../../core/errors/failure.dart';
-import '../entities/user.dart';
 
 abstract class AuthRepository {
   //카카오 로그인
-  Future<Either<Failure, User>> signInWithKakao();
+  Future<Either<Failure, ApiResponse<User>>> signInWithKakao();
 
   // 로그아웃
   Future<Either<Failure, void>> signOut();

--- a/lib/features/auth/domain/repositories/auth_reopository.dart
+++ b/lib/features/auth/domain/repositories/auth_reopository.dart
@@ -1,0 +1,12 @@
+import 'package:dartz/dartz.dart';
+
+import '../../../../core/errors/failure.dart';
+import '../entities/user.dart';
+
+abstract class AuthRepository {
+  //카카오 로그인
+  Future<Either<Failure, User>> signInWithKakao();
+
+  // 로그아웃
+  Future<Either<Failure, void>> signOut();
+}

--- a/lib/features/auth/domain/usecases/login_usecase.dart
+++ b/lib/features/auth/domain/usecases/login_usecase.dart
@@ -1,0 +1,23 @@
+import 'package:dartz/dartz.dart';
+import 'package:trip_view/core/errors/failure.dart';
+
+import '../entities/user.dart';
+import '../repositories/auth_reopository.dart';
+
+enum LoginMethod {
+  kakao,
+  // 추후 로그인 프로바이더 추가 시 명시
+}
+
+class LoginUseCase {
+  final AuthRepository repository;
+
+  LoginUseCase(this.repository);
+
+  Future<Either<Failure, User>> call(LoginMethod method) async {
+    switch (method) {
+      case LoginMethod.kakao:
+        return await repository.signInWithKakao();
+    }
+  }
+}

--- a/lib/features/auth/domain/usecases/login_usecase.dart
+++ b/lib/features/auth/domain/usecases/login_usecase.dart
@@ -1,7 +1,8 @@
 import 'package:dartz/dartz.dart';
 import 'package:trip_view/core/errors/failure.dart';
+import 'package:trip_view/core/network/response_model.dart';
+import 'package:trip_view/features/auth/domain/entities/user.dart';
 
-import '../entities/user.dart';
 import '../repositories/auth_reopository.dart';
 
 enum LoginMethod {
@@ -14,7 +15,7 @@ class LoginUseCase {
 
   LoginUseCase(this.repository);
 
-  Future<Either<Failure, User>> call(LoginMethod method) async {
+  Future<Either<Failure, ApiResponse<User>>> call(LoginMethod method) async {
     switch (method) {
       case LoginMethod.kakao:
         return await repository.signInWithKakao();

--- a/lib/features/auth/presentation/bindings/auth_binding.dart
+++ b/lib/features/auth/presentation/bindings/auth_binding.dart
@@ -1,0 +1,20 @@
+import 'package:get/get.dart';
+import 'package:trip_view/features/auth/data/datasources/auth_data_source.dart';
+import 'package:trip_view/features/auth/data/repositories/%08auth_repository_impl.dart';
+import 'package:trip_view/features/auth/domain/repositories/auth_reopository.dart';
+import 'package:flutter/foundation.dart';
+
+class AuthBinding extends Bindings {
+  @override
+  void dependencies() {
+    if (kReleaseMode) {
+      Get.lazyPut<AuthDataSource>(() => AuthDataSourceImpl()); // 실제 API 호출
+    } else {
+      Get.lazyPut<AuthDataSource>(() => AuthMockDataSourceImpl()); // Mock 데이터
+    }
+
+    Get.lazyPut<AuthRepository>(
+      () => AuthRepositoryImpl(Get.find<AuthDataSource>()),
+    );
+  }
+}

--- a/lib/features/auth/presentation/bindings/auth_binding.dart
+++ b/lib/features/auth/presentation/bindings/auth_binding.dart
@@ -1,6 +1,6 @@
 import 'package:get/get.dart';
 import 'package:trip_view/features/auth/data/datasources/auth_data_source.dart';
-import 'package:trip_view/features/auth/data/repositories/%08auth_repository_impl.dart';
+import 'package:trip_view/features/auth/data/repositories/auth_repository_impl.dart';
 import 'package:trip_view/features/auth/domain/repositories/auth_reopository.dart';
 import 'package:flutter/foundation.dart';
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
-import 'package:kakao_flutter_sdk_user/kakao_flutter_sdk_user.dart';
+import 'package:kakao_flutter_sdk_auth/kakao_flutter_sdk_auth.dart';
 
 void main() {
   WidgetsFlutterBinding.ensureInitialized();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,15 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:kakao_flutter_sdk_user/kakao_flutter_sdk_user.dart';
 
 void main() {
+  WidgetsFlutterBinding.ensureInitialized();
+
+  KakaoSdk.init(
+    nativeAppKey: dotenv.env['KAKAO_NATIVE_APP_KEY'],
+    javaScriptAppKey: dotenv.env['KAKAO_JAVASCRIPT_APP_KEY'],
+  );
+
   runApp(const MyApp());
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,13 +31,16 @@ dependencies:
   flutter:
     sdk: flutter
 
-
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
 
   # 데이터 타입 처리를 위한 라이브러리
   dartz: ^0.10.1
+  #카카오 로그인
+  kakao_flutter_sdk_user: ^1.9.5
+  # 환경변수 관리
+  flutter_dotenv: ^5.2.1
 
 dev_dependencies:
   flutter_test:
@@ -61,33 +64,5 @@ flutter:
   # the material Icons class.
   uses-material-design: true
 
-  # To add assets to your application, add an assets section, like this:
-  # assets:
-  #   - images/a_dot_burr.jpeg
-  #   - images/a_dot_ham.jpeg
-
-  # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.dev/to/resolution-aware-images
-
-  # For details regarding adding assets from package dependencies, see
-  # https://flutter.dev/to/asset-from-package
-
-  # To add custom fonts to your application, add a fonts section here,
-  # in this "flutter" section. Each entry in this list should have a
-  # "family" key with the font family name, and a "fonts" key with a
-  # list giving the asset and other descriptors for the font. For
-  # example:
-  # fonts:
-  #   - family: Schyler
-  #     fonts:
-  #       - asset: fonts/Schyler-Regular.ttf
-  #       - asset: fonts/Schyler-Italic.ttf
-  #         style: italic
-  #   - family: Trajan Pro
-  #     fonts:
-  #       - asset: fonts/TrajanPro.ttf
-  #       - asset: fonts/TrajanPro_Bold.ttf
-  #         weight: 700
-  #
-  # For details regarding fonts from package dependencies,
-  # see https://flutter.dev/to/font-from-package
+  assets:
+    - .env

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,9 +38,13 @@ dependencies:
   # 데이터 타입 처리를 위한 라이브러리
   dartz: ^0.10.1
   #카카오 로그인
-  kakao_flutter_sdk_user: ^1.9.5
+  kakao_flutter_sdk_auth: ^1.9.6
   # 환경변수 관리
   flutter_dotenv: ^5.2.1
+  # http 통신
+  dio: ^5.7.0
+  # 상태관리
+  get: ^4.6.6
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,6 +36,9 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
 
+  # 데이터 타입 처리를 위한 라이브러리
+  dartz: ^0.10.1
+
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
### 📎  #1 

- 카카오 로그인 구현

### 📃 작업 내용

- domain / data 영역 구현

### 🫨 고민한 부분

- 폴더 구조를 고민하다 지금 형태로 잡았습니다. 

- failure는 공통 failure를 만들고 기능 별 failure가 해당 추상 클래스를 상속하도록 했어요.

- Either를 활용하여 가독성을 좋게 만들어보려고 했는데 좀 더 사용해봐야 알 것 같아요. [레퍼런스 - flutter에 함수형 예외처리 적용해보기.](https://tech.e3view.com/flutter/)

- usecase를 소셜 로그인 프로바이더별로 쪼개야 하나 하다가 저희 요구사항이 카카오, 네이버, 애플 세 가지라 소셜 로그인을 하나의 기능으로 보고 login_usecase 로 명시했어요. 추후 구현할 때는 LoginMethod 타입으로 구분하도록요. 


### 📌 중점적으로 볼 부분

- 전반전인 구조를 봐주시면 좋을 것 같아요! 
domain / data 순으로 보면 될 것 같습니다.
presentation layer는 백엔드 구현되면 작업 들어가려고 합니다.
env 설정이 필요한데, 저희 노션 "문서 - 프론트 협업 컨벤션"에 env 파일 명시해두었으니, 해당 위치에 설정하면 될 것 같아요.

### 🎇 동작 화면 or 테스트 결과

- 

### 💫 기타 사항

- 

### ✅ 체크 리스트

- [ ]  Presentation Layer(View, ViewModel)를 체크했나요?
- [x]  Domain Layer(Entities, UseCases, Repository Interface)를 체크했나요?
- [x]  Data Layer(Repositories Implementation, API(Network), Persistence DB)를 체크했나요?