### PR TITLE
Feature/naver login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,6 +97,7 @@ lib/generated_plugin_registrant.dart
 ## User settings
 xcuserdata/
 *.xcconfig
+ios/Config.xcconfig
 
 ## Xcode 8 and earlier
 *.xcscmblueprint

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -10,4 +10,12 @@ import UIKit
     GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
+
+  override func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {        
+      if url.scheme == "tripView" {
+          return super.application(app, open: url, options: options)
+      }
+
+      return true
+  }
 }

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -22,6 +22,7 @@
 	<string>$(FLUTTER_BUILD_NAME)</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
+	<!--Url Scheme Setting-->
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -31,16 +32,23 @@
 			<array>
 				<string>kakao${KAKAO_NATIVE_APP_KEY}</string>
 			</array>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>tripView</string>
+			</array>
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>KAKAO_NATIVE_APP_KEY</key>
 	<string>${KAKAO_NATIVE_APP_KEY}</string>
+	<!--Query Scheme Setting-->
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>kakaokompassauth</string>
 		<string>kakaolink</string>
+		<string>naversearchapp</string>
+		<string>naversearchthirdlogin</string>
 	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>

--- a/lib/core/errors/auth_failure.dart
+++ b/lib/core/errors/auth_failure.dart
@@ -13,3 +13,8 @@ class KakaoSignInFailure extends AuthFailure {
 class SignOutFailure extends AuthFailure {
   SignOutFailure(super.message);
 }
+
+// 네이버 로그인 실패
+class NaverSignInFailure extends AuthFailure {
+  NaverSignInFailure(super.message);
+}

--- a/lib/features/auth/data/datasources/auth_data_source.dart
+++ b/lib/features/auth/data/datasources/auth_data_source.dart
@@ -3,6 +3,7 @@ import 'package:trip_view/features/auth/domain/entities/user.dart';
 
 abstract class AuthDataSource {
   Future<ApiResponse<User>> getTokenWithKakaoAuthCode(String authCode);
+  Future<ApiResponse<User>> getTokenWithNaverAuthCode(String authCode);
   Future<void> signOut();
 }
 
@@ -29,6 +30,27 @@ class AuthMockDataSourceImpl implements AuthDataSource {
   }
 
   @override
+  Future<ApiResponse<User>> getTokenWithNaverAuthCode(String authCode) async {
+    // 실제 API 호출처럼 보이게 딜레이 추가
+    await Future.delayed(const Duration(seconds: 2));
+
+    return ApiResponse(
+      statusCode: 200,
+      message: "로그인 성공",
+      timestamp: DateTime.now(),
+      requestURL: "/auth/naver",
+      data: User(
+          id: "mock_user_id",
+          name: "홍길동",
+          email: "test@example.com",
+          nickname: "길동이",
+          profileImageUrl: "https://example.com/profile.jpg",
+          accessToken: "mock_access_token_${authCode}",
+          refreshToken: "mock_refresh_token"),
+    );
+  }
+
+  @override
   Future<void> signOut() {
     // 추후 구현
     throw UnimplementedError();
@@ -39,6 +61,12 @@ class AuthDataSourceImpl implements AuthDataSource {
   @override
   Future<ApiResponse<User>> getTokenWithKakaoAuthCode(String authCode) {
     // 추후 구현
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<ApiResponse<User>> getTokenWithNaverAuthCode(String authCode) {
+    // 추후 실제 API 구현
     throw UnimplementedError();
   }
 

--- a/lib/features/auth/data/repositories/auth_repository_impl.dart
+++ b/lib/features/auth/data/repositories/auth_repository_impl.dart
@@ -1,5 +1,7 @@
+import 'dart:async';
 import 'package:dartz/dartz.dart';
 import 'package:kakao_flutter_sdk_auth/kakao_flutter_sdk_auth.dart';
+import 'package:naver_login_sdk/naver_login_sdk.dart';
 import 'package:trip_view/core/errors/failure.dart';
 import 'package:trip_view/core/network/response_model.dart';
 import 'package:trip_view/features/auth/data/datasources/auth_data_source.dart';
@@ -38,6 +40,46 @@ class AuthRepositoryImpl implements AuthRepository {
       }
     } catch (e) {
       return Left(KakaoSignInFailure(e.toString()));
+    }
+  }
+
+  @override
+  Future<Either<Failure, ApiResponse<User>>> signInWithNaver() async {
+    try {
+      // 1. 인가 코드 발급
+      String? authCode;
+      try {
+        final completer = Completer<String?>();
+
+        await NaverLoginSDK.authenticate(
+          callback: OAuthLoginCallback(
+            onSuccess: () async {
+              final token = await NaverLoginSDK.getAccessToken();
+              completer.complete(token);
+            },
+            onFailure: (httpStatus, message) {
+              completer.completeError(message);
+            },
+            onError: (errorCode, message) {
+              completer.completeError(message);
+            },
+          ),
+        );
+
+        authCode = await completer.future;
+      } on Exception catch (e) {
+        return Left(NaverSignInFailure("네이버 인가 코드 발급 실패: ${e.toString()}"));
+      }
+
+      // 2. 인가 코드를 사용하여 토큰 발급
+      if (authCode != null && authCode.isNotEmpty) {
+        final response = await dataSource.getTokenWithNaverAuthCode(authCode);
+        return Right(response);
+      } else {
+        return Left(NaverSignInFailure("인가 코드 발급 실패"));
+      }
+    } catch (e) {
+      return Left(NaverSignInFailure(e.toString()));
     }
   }
 

--- a/lib/features/auth/domain/repositories/auth_reopository.dart
+++ b/lib/features/auth/domain/repositories/auth_reopository.dart
@@ -8,6 +8,9 @@ abstract class AuthRepository {
   //카카오 로그인
   Future<Either<Failure, ApiResponse<User>>> signInWithKakao();
 
+  //네이버 로그인
+  Future<Either<Failure, ApiResponse<User>>> signInWithNaver();
+
   // 로그아웃
   Future<Either<Failure, void>> signOut();
 }

--- a/lib/features/auth/domain/usecases/login_usecase.dart
+++ b/lib/features/auth/domain/usecases/login_usecase.dart
@@ -7,6 +7,7 @@ import '../repositories/auth_reopository.dart';
 
 enum LoginMethod {
   kakao,
+  naver
   // 추후 로그인 프로바이더 추가 시 명시
 }
 
@@ -19,6 +20,8 @@ class LoginUseCase {
     switch (method) {
       case LoginMethod.kakao:
         return await repository.signInWithKakao();
+      case LoginMethod.naver:
+        return await repository.signInWithNaver();
     }
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:kakao_flutter_sdk_auth/kakao_flutter_sdk_auth.dart';
+import 'package:naver_login_sdk/naver_login_sdk.dart';
 
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
@@ -8,6 +9,13 @@ void main() {
   KakaoSdk.init(
     nativeAppKey: dotenv.env['KAKAO_NATIVE_APP_KEY'],
     javaScriptAppKey: dotenv.env['KAKAO_JAVASCRIPT_APP_KEY'],
+  );
+
+  NaverLoginSDK.initialize(
+    urlScheme: dotenv.env['NAVER_URL_SCHEME'] ?? '',
+    clientId: dotenv.env['NAVER_CLIENT_ID'] ?? '',
+    clientSecret: dotenv.env['NAVER_CLIENT_SECRET'] ?? '',
+    clientName: dotenv.env['NAVER_CLIENT_NAME'] ?? '',
   );
 
   runApp(const MyApp());

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,6 +45,8 @@ dependencies:
   dio: ^5.7.0
   # 상태관리
   get: ^4.6.6
+  # 네이버 로그인
+  naver_login_sdk: ^1.0.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### 📎 close #3 

- 네이버 로그인 구현

### 📃 작업 내용

- domain / data 영역 구현

### 🫨 고민한 부분

- 현재는 datasource 구현체에서 카카오와 네이버 프로바이더의 서버 토큰 발급 메서드가 분리되어 있습니다.
추후 백엔드와 얘기하여 구현사항을 보고 하나의 메서드로 합치면 좋지 않을까 생각해봤습니다.

### 📌 중점적으로 볼 부분

-  네이버 로그인 시에 콜백 처리를 해야 하는데, Completer를 사용하여 처리하였습니다.

### 🎇 동작 화면 or 테스트 결과

- 

### 💫 기타 사항

- 

### ✅ 체크 리스트

- [x]  Presentation Layer(View, ViewModel)를 체크했나요?
- [x]  Domain Layer(Entities, UseCases, Repository Interface)를 체크했나요?
- [ ]  Data Layer(Repositories Implementation, API(Network), Persistence DB)를 체크했나요?
